### PR TITLE
🚑 HOTFIX: Proper compilation

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "database"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/backend/database/Cargo.toml
+++ b/backend/database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "database"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
- Avoid recursion in async fn by assuming the Err follows a happy path after some preprocessing. Wrote some `.expect` if anything goes wrong in the future.
- Apparently, stacking cfg features, like so
    ```rs
    #cfg[(feature="sqlite")]
    #cfg[(feature="postgres")]
    impl S {}
    ```
    is equivalent to `#[cfg(all(feature="sqlite", feature="postgres"))]` making the impl invisible. I have changed it to `#[cfg(any(feature="sqlite", feature="postgres"))]` and hack some compilation failure if both features are together.